### PR TITLE
Add image configuration for rick and morty api

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "rickandmortyapi.com",
+        pathname: "/api/character/avatar/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
This pull request updates the `next.config.ts` file to enhance image handling by allowing remote images from a specific external API.

Configuration updates:

* [`next.config.ts`](diffhunk://#diff-e3f38f2f0e7ba92f0dd56c086ec5de704229d58d5371e8cc57e43961757d8c7bL4-R12): Added an `images` configuration with `remotePatterns` to enable loading images from the `rickandmortyapi.com` domain, specifically under the `/api/character/avatar/**` path.