### PR TITLE
Add react-icons dependency to package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "next": "15.3.1",
         "react": "^19.0.0-rc-de68d2f4-20241204",
         "react-dom": "^19.0.0-rc-de68d2f4-20241204",
+        "react-icons": "^5.5.0",
         "redux-saga": "^1.3.0",
         "rickmortyapi": "^2.3.0"
       },
@@ -8312,6 +8313,15 @@
       },
       "peerDependencies": {
         "react": "19.0.0-rc-de68d2f4-20241204"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "next": "15.3.1",
     "react": "^19.0.0-rc-de68d2f4-20241204",
     "react-dom": "^19.0.0-rc-de68d2f4-20241204",
+    "react-icons": "^5.5.0",
     "redux-saga": "^1.3.0",
     "rickmortyapi": "^2.3.0"
   },


### PR DESCRIPTION
Dependency updates:

* Added the `react-icons` library with version `^5.5.0` to the dependencies in `package.json`. This library provides a collection of popular icons as React components.